### PR TITLE
fix(ci): add version info to commit messages

### DIFF
--- a/updatecli/updatecli.d/grafana.yaml
+++ b/updatecli/updatecli.d/grafana.yaml
@@ -6,7 +6,7 @@ sources:
       name: 'k8s-monitoring'
 targets:
   grafana_chart:
-    name: bump chart version
+    name: bump chart version to {{ source "lastGrafanaHelmRelease" }}
     kind: yaml
     scmid: github
     sourceid: lastGrafanaHelmRelease
@@ -53,4 +53,4 @@ actions:
       draft: false
       labels:
       - "dependencies"
-      title: "chore(deps): update Grafana K8s Monitoring version"
+      title: 'chore(deps): update Grafana K8s Monitoring version to {{ source "lastGrafanaHelmRelease" }}'


### PR DESCRIPTION
Updates the title of the Grafana K8s Monitoring version 
to reflect the dynamic sourcing of the latest Helm release. 
Also modifies the target name to ensure it indicates the 
use of the latest release version for better clarity.