### PR TITLE
refactor: remove unnecessary prefix and suffix transformers

### DIFF
--- a/updatecli/updatecli.d/grafana.yaml
+++ b/updatecli/updatecli.d/grafana.yaml
@@ -13,9 +13,6 @@ targets:
     spec:
       file: 'grafana/kustomization.yaml'
       key: '$.helmCharts[0].version'
-    transformers:
-    - addprefix: "'"
-    - addsuffix: "'"
   kubectl:
     name: run kubectl when chart changed
     kind: shell


### PR DESCRIPTION
Eliminate the unused prefix and suffix transformers from the 
Grafana YAML configuration. This simplifies the file and 
ensures that Helm chart version updates are handled 
efficiently without extra formatting complications.