### PR TITLE
feat(config): disable kustomize in renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>opzkit/renovate-config"
-  ]
+  ],
+  "kustomize": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
Adds "kustomize" configuration to disable its usage in the 
Renovate setup, aligning the configuration with project 
requirements and preventing unnecessary updates.