### PR TITLE
fix: update apiVersion for external secrets to v1

### DIFF
--- a/external-secrets.yaml.tftpl
+++ b/external-secrets.yaml.tftpl
@@ -1,6 +1,6 @@
 %{ if length(external_secrets_keys.loki) > 0 }
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: ${logs_secret}
@@ -20,7 +20,7 @@ spec:
     creationPolicy: Owner
     deletionPolicy: Retain
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: ${metrics_secret}
@@ -40,7 +40,7 @@ spec:
     creationPolicy: Owner
     deletionPolicy: Retain
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: ${traces_secret}


### PR DESCRIPTION
Changes the apiVersion of ExternalSecret resources from v1beta1 
to v1 in external-secrets.yaml.tftpl for better stability and to 
align with the latest API standards.