### PR TITLE
feat(updatecli): enable title usage for automerge in Grafana config

### DIFF
--- a/updatecli/updatecli.d/grafana.yaml
+++ b/updatecli/updatecli.d/grafana.yaml
@@ -47,6 +47,7 @@ actions:
     spec:
       automerge: true
       mergemethod: squash
+      usetitleforautomerge: true
       draft: false
       labels:
       - "dependencies"


### PR DESCRIPTION
Adds the `usetitleforautomerge` option to the Grafana updatecli 
configuration to ensure that pull requests use the commit title 
for the automerge process. This improves clarity and consistency 
in commit messages for dependencies updates.