### PR TITLE
feat(k8s): add memory requests for alloy components

### DIFF
--- a/grafana/operator-values.yaml
+++ b/grafana/operator-values.yaml
@@ -60,14 +60,23 @@ clusterMetrics:
     enabled: true
 alloy-metrics:
   enabled: true
+  alloy:
+    requests:
+      memory: 400m
 clusterEvents:
   enabled: true
 alloy-singleton:
   enabled: true
+  alloy:
+    requests:
+      memory: 70m
 podLogs:
   enabled: true
 alloy-logs:
   enabled: true
+  alloy:
+    requests:
+      memory: 80m
 applicationObservability:
   enabled: true
   receivers:
@@ -96,6 +105,8 @@ alloy-receiver:
         port: 9411
         targetPort: 9411
         protocol: TCP
+    requests:
+      memory: 70m
 annotationAutodiscovery:
   enabled: true
 prometheusOperatorObjects:


### PR DESCRIPTION
Add specific memory requests for the alloy components in the
k8s-monitoring and operator-values configuration files to
improve resource management and ensure adequate performance.
The changes set memory requests to 80m, 70m, and 400m for
various alloy components.