### PR TITLE
fix(grafana): standardize resource requests in operator-values.yaml

### DIFF
--- a/grafana/operator-values.yaml
+++ b/grafana/operator-values.yaml
@@ -61,22 +61,25 @@ clusterMetrics:
 alloy-metrics:
   enabled: true
   alloy:
-    requests:
-      memory: 400m
+    resources:
+      requests:
+        memory: 400m
 clusterEvents:
   enabled: true
 alloy-singleton:
   enabled: true
   alloy:
-    requests:
-      memory: 70m
+    resources:
+      requests:
+        memory: 70m
 podLogs:
   enabled: true
 alloy-logs:
   enabled: true
   alloy:
-    requests:
-      memory: 80m
+    resources:
+      requests:
+        memory: 80m
 applicationObservability:
   enabled: true
   receivers:
@@ -105,8 +108,9 @@ alloy-receiver:
         port: 9411
         targetPort: 9411
         protocol: TCP
-    requests:
-      memory: 70m
+    resources:
+      requests:
+        memory: 70m
 annotationAutodiscovery:
   enabled: true
 prometheusOperatorObjects:


### PR DESCRIPTION
Updates the resource allocation structure for alloy metrics, 
singleton, and logs in operator-values.yaml to use a consistent 
`resources` key format for memory requests. This change enhances 
clarity and maintains uniformity across the configuration file.