### PR TITLE
feat: add alloy operator configuration to Grafana

### DIFF
--- a/grafana/operator-values.yaml
+++ b/grafana/operator-values.yaml
@@ -92,6 +92,15 @@ applicationObservability:
     zipkin:
       enabled: true
       includeDebugMetrics: true
+alloy-operator:
+  deploy: true
+  resources:
+    limits:
+      cpu: 650m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
 alloy-receiver:
   enabled: true
   alloy:


### PR DESCRIPTION
Adds configuration for the alloy operator in operator-values.yaml, enabling 
its deployment and specifying resource limits and requests. Updates the 
CPU limit in k8s-monitoring.yaml.tftpl from 500m to 650m for enhanced 
performance and ensures better resource allocation.