### PR TITLE
fix: update app-id to use vars instead of secrets

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,7 @@ jobs:
         id: get_token
         uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2
         with:
-          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4


### PR DESCRIPTION
Changes the `app-id` in the release workflow to use 
`vars.RELEASE_PLEASE_APP_ID` instead of 
`secrets.RELEASE_PLEASE_APP_ID` for better clarity and 
manageability in the GitHub Actions configuration.