### PR TITLE
fix: anchor metric_drop_rules injection on stable endpoint/wal boundary

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -21,18 +21,23 @@ locals {
   }), "$$", "$")
 
   # Generate write_relabel_config blocks for each metric drop rule.
-  # These are injected into all prometheus.remote_write endpoints to
-  # prevent matching metrics from being sent to the remote backend.
+  # Injected inside the prometheus.remote_write "metricsservice" endpoint
+  # block so matching metrics are dropped before remote write.
   metric_drop_configs = join("", [
     for pattern in var.metric_drop_rules :
     "        write_relabel_config {\n          source_labels = [\"__name__\"]\n          regex = \"${pattern}\"\n          action = \"drop\"\n        }\n"
   ])
 
-  # Inject drop rules after the last write_relabel_config in each
-  # prometheus.remote_write block (the k8s_cluster_name relabel rule).
-  relabel_anchor      = "target_label = \"k8s_cluster_name\"\n        }"
-  relabel_replacement = "target_label = \"k8s_cluster_name\"\n        }\n${local.metric_drop_configs}"
-  yaml                = length(var.metric_drop_rules) > 0 ? replace(local.rendered, local.relabel_anchor, local.relabel_replacement) : local.rendered
+  # Anchor on the endpoint-close / wal-open boundary, which is stable across
+  # k8s-monitoring chart 4.x. Fail fast if the anchor disappears in a future
+  # chart bump so the silent no-op from chart 4.0.4 cannot recur.
+  relabel_anchor      = "      }\n\n      wal {"
+  relabel_replacement = "${local.metric_drop_configs}      }\n\n      wal {"
+  yaml = (
+    length(var.metric_drop_rules) == 0 ? local.rendered :
+    strcontains(local.rendered, local.relabel_anchor) ? replace(local.rendered, local.relabel_anchor, local.relabel_replacement) :
+    file("ERROR: metric_drop_rules anchor not found in rendered k8s-monitoring template - upstream chart layout changed, update relabel_anchor in locals.tf")
+  )
 
   secrets_yaml = templatefile("${path.module}/external-secrets.yaml.tftpl", {
     external_secrets_keys     = var.external_secrets_keys


### PR DESCRIPTION
## Summary
- k8s-monitoring chart 4.0.4 (#361) replaced the `write_relabel_config` cluster label block with `external_labels`, removing the `target_label = "k8s_cluster_name"` string the previous anchor relied on. Terraform `replace()` silently no-ops when the anchor is missing, so anyone upgrading to v1.1.3+ has been emitting every metric they had listed in `metric_drop_rules`.
- Re-anchor injection on the endpoint-close / wal-open boundary inside `prometheus.remote_write "metricsservice"` (stable across chart 4.0.x and 4.1.x). The block now lands inside `endpoint { ... }` where Alloy expects `write_relabel_config`.
- Add a `strcontains` guard that hard-fails rendering if the anchor disappears again, so a future chart layout change can't silently regress filtering.

## Impact
On an affected cluster, dropped-but-still-ingested series included:

| Metric | Series |
|---|---|
| `kube_replicaset_*` (9 metrics) | ~6,354 |
| `kube_pod_status_reason` | ~975 |
| `kube_secret_metadata_resource_version` | ~343 |
| `container_fs_(reads\|writes)_*` | ~600+ |

## Test plan
- [x] `terraform console` render with `metric_drop_rules = [...]` — confirmed `write_relabel_config` blocks now appear inside `endpoint { ... }` after `queue_config` and before `wal { ... }`
- [x] `terraform console` render with `metric_drop_rules = []` — confirmed `local.yaml == local.rendered`
- [x] `prek run --all-files` — all checks pass (terraform validate, tflint, fmt, checkov)
- [ ] Verify on a real cluster: `kubectl get cm -n monitoring k8s-monitoring -o yaml | grep write_relabel_config` shows the injected blocks