### PR TITLE
fix(grafana): set memory request on alloy-logs collector

### DIFF
--- a/grafana/operator-values.yaml
+++ b/grafana/operator-values.yaml
@@ -88,6 +88,10 @@ collectors:
     presets:
       - daemonset
       - filesystem-log-reader
+    alloy:
+      resources:
+        requests:
+          memory: 256Mi
   alloy:
     presets:
       - statefulset

--- a/k8s-monitoring.yaml.tftpl
+++ b/k8s-monitoring.yaml.tftpl
@@ -4980,7 +4980,7 @@ metadata:
 apiVersion: v1
 data:
   cluster: ${cluster_name}
-  self-reporting-metric.prom: |+
+  self-reporting-metric.prom: |
     # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
     # TYPE grafana_kubernetes_monitoring_build_info gauge
     grafana_kubernetes_monitoring_build_info{version="4.1.6", namespace="monitoring"} 1
@@ -5000,9 +5000,6 @@ data:
     grafana_kubernetes_monitoring_collector_info{kind="statefulset", name="alloy", presets="statefulset", replicas="1", type="alloy"} 1
     grafana_kubernetes_monitoring_collector_info{kind="daemonset", name="alloy-logs", presets="daemonset,filesystem-log-reader", type="alloy"} 1
     # EOF
-
-
-
 kind: ConfigMap
 metadata:
   name: k8s-monitoring-release-info
@@ -5800,7 +5797,9 @@ spec:
     mounts:
       dockercontainers: true
       varlog: true
-    resources: {}
+    resources:
+      requests:
+        memory: 256Mi
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:


### PR DESCRIPTION
## Problem
The `alloy-logs` daemonset collector added in #402 has no resource requests. On clusters running a LimitRange that injects a large default memory request for requestless containers (e.g. unbound's `default-request-adder`, which sets `defaultRequest.memory: 1Pi`), every alloy-logs pod inherits that default and becomes **unschedulable** (`Insufficient memory`). The singleton `alloy` collector is unaffected because it sets its own request.

## Fix
Set an explicit `256Mi` memory request on the `alloy-logs` collector. A log-tailing daemon genuinely uses memory (buffers + file positions), so this is a realistic reservation rather than a token value.

## Verification
`kubectl kustomize . --enable-helm` renders the `k8s-monitoring-alloy-logs` Alloy CR with `resources.requests.memory: 256Mi`; pod-logs pipeline (`loki.source.file`) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)